### PR TITLE
fix 'str' object has no attrubute 'decode' in neovim

### DIFF
--- a/plugin/PinyinSearch.vim
+++ b/plugin/PinyinSearch.vim
@@ -1,3 +1,4 @@
+
 " dict from http://lingua.mtsu.edu/chinese-computing/statistics/char/list.php?Which=IN
 func! s:Pinyin(table, char)
     call clearmatches()
@@ -6,21 +7,21 @@ import vim,sys
 ENCODING = vim.eval("&fileencoding")
 if not ENCODING or ENCODING == 'none':
     ENCODING = 'utf-8'
-table = vim.eval("a:table");
-chars = vim.eval("a:char").decode(ENCODING)
+table = vim.eval("a:table")
+chars = vim.eval("a:char")
 charlen = len(chars)
 if charlen == 0:
 	vim.command("return") # XXX error on no input
 cur = vim.current; window = cur.window; buf = cur.buffer
 Dict = {}
-with open(table, 'r') as f:
+with open(table, 'r', encoding='utf-8') as f:
     def update(ch, s):
         Dict.setdefault(ch, [])
         Dict[ch].extend(s)
 
     for line in f.readlines():
         sp = line.split(' ')
-        update(sp[0].decode(ENCODING), map(lambda x: x.strip(), sp[1:]))
+        update(sp[0], map(lambda x: x.strip(), sp[1:]))
 
         #with open('/tmp/tmp', 'w') as f:
         #    f.write(str(Dict))
@@ -48,14 +49,14 @@ def find_next(line):
         return r - charlen
 
 def gen_list():
-    text = ''.join(map(lambda x : x.strip(), buf)).decode(ENCODING)
+    text = ''.join(map(lambda x : x.strip(), buf))
     l = 0
     ret = list()
     while True:
         r = find_next(text[l:])
         if r >= 0:
             word = text[(l + r) : (l + r + charlen)]
-            ret.append(word.encode(ENCODING))
+            ret.append(word)
             l = l + r + 1
         else :
             return ret


### PR DESCRIPTION
您好，我最近在用vim来写markdown文档。找了很久才找到您的vim中文拼音跳转的插件
但是我用neovim安装使用时，插件报错'str' object has no attrubute 'decode' in neovim
可能是python的问题
所以我把错误修改了一下。
虽然这个插件已经很久没有更新了。
但这是我在全网找到的唯一符合要求的vim插件。
非常感谢您的代码，真的太棒了。